### PR TITLE
Add a test deployment to prevent bricking singleton and universal

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "0xsequence": "^1.2.3",
-    "@0xsequence/solidity-deployer": "^0.1.1",
+    "@0xsequence/solidity-deployer": "^0.1.4",
     "@typechain/ethers-v5": "^7.0.1",
     "@typescript-eslint/eslint-plugin": "^4.18.0",
     "@typescript-eslint/parser": "^4.18.0",

--- a/scripts/deploy-contracts.ts
+++ b/scripts/deploy-contracts.ts
@@ -93,6 +93,16 @@ export const deployContracts = async (config: Config): Promise<string | null> =>
       return 'Signer has pending transactions'
     }
 
+    // Run a test deployment to check if the deployers will work without bricking them...
+    try {
+      const testDeployer = new deployers.TestDeployer(signer, prompt)
+      await testDeployer.deploy('WalletFactory', FactoryV1, 0, txParams)
+    } catch (e) {
+      prompt.fail('Test deployment failed, aborting')
+      console.error(e)
+      return 'Test deployment failed'
+    }
+
     const universalDeployer = new deployers.UniversalDeployer(signer, prompt) //, undefined, BigNumber.from('35000000000000000'))
     const singletonDeployer = new deployers.SingletonDeployer(signer, prompt) //, undefined, BigNumber.from('30000000000000000'))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,10 +187,10 @@
     "@0xsequence/core" "1.10.12"
     ethers "^5.5.2"
 
-"@0xsequence/solidity-deployer@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@0xsequence/solidity-deployer/-/solidity-deployer-0.1.1.tgz#8767964bb9b1c786e3a75c3d3405322c5cc77ce1"
-  integrity sha512-Kl+mKMgiuoUC5oF4AzNyd32m7TJBSnuSgh7W73oxbqbynnxRVSlGv+AGyGvbRPGut5PcHOrqUvgRHAvYhPHHUQ==
+"@0xsequence/solidity-deployer@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@0xsequence/solidity-deployer/-/solidity-deployer-0.1.4.tgz#2f5d4aeb121b8ef5a8cff35caf88868e3567b726"
+  integrity sha512-KjR11oekEgI8tzwE1FsZgdaz9G5Y4bkY6spFXqAtuMr8rpKVD7/sIXHYNHtn/USi5dutLLFPdpVVpRKUg+HZug==
   dependencies:
     "@tenderly/sdk" "^0.1.14"
     axios "^1.3.5"


### PR DESCRIPTION
Adds a "TestDeployer" that generates and sends a deployer transaction similar to our Singleton and Universal deployers. We use this so that in the unlikely (but surprisingly common) event a deployment to a non-standard EVM chain has an error and causes a nonce increment, we do not brick the deployment flow. 
If the Singleton and Universal deployers are already deployed, this will just attempt to deploy the wallet factory using the Universal deployer and not waste cycles. 
https://github.com/0xsequence/solidity-deployer/blob/main/src/deployers/TestDeployer.ts